### PR TITLE
improvements to argument parsing

### DIFF
--- a/feedtoflatfiles.py
+++ b/feedtoflatfiles.py
@@ -262,9 +262,9 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-	if args.output_format=='element':
-		feed_to_element_files(args)
-	elif args.output_format=='database':
-		if not args.directory:
-			parser.error("A directory must be specified.")
-		feed_to_db_files(args.directory, args.feed_file)
+    if args.output_format=='element':
+        feed_to_element_files(args)
+    elif args.output_format=='database':
+        if not args.directory:
+            parser.error("A directory must be specified.")
+        feed_to_db_files(args.directory, args.feed_file)


### PR DESCRIPTION
When running the default output format (database), an output directory needs to be specified. I added logic to provide an appropriate error if the output directory is missing. I also fixed the extant_file() function so it passes the error it throws properly. Finally, we can use also extant_file() to check if the output directory exists, so I applied that function to the directory argument's type.
