### PR TITLE
Strip newlines from an element's text

### DIFF
--- a/feedtoflatfiles.py
+++ b/feedtoflatfiles.py
@@ -7,6 +7,9 @@ from schemaprops import SchemaProps
 
 SCHEMA_URL = "https://github.com/votinginfoproject/vip-specification/raw/v3-archive/vip_spec_v3.0.xsd"
 
+def format_element_text(elem):
+        return ' '.join([line.strip() for line in elem.text.splitlines()])
+
 def clear_element(element):
 	element.clear()
 	while element.getprevious() is not None:
@@ -58,10 +61,11 @@ def process_sub_elems(elem, elem_fields):
 			add_elems = sub_elem.getchildren()
 
 			for add_elem in add_elems:
-				elem_dict[sub_elem.tag + "_" + add_elem.tag] = add_elem.text
+				elem_dict[sub_elem.tag + "_" + add_elem.tag] = format_element_text(add_elem)
 
 		elif len(elem_dict[sub_elem.tag]) > 0:
-			extras.append({sub_elem.tag:{"val":sub_elem.text, "attributes":sub_elem.attrib}})
+			extras.append({sub_elem.tag:{"val": format_element_text(sub_elem),
+                                                     "attributes": sub_elem.attrib}})
 		else:
 			elem_dict[sub_elem.tag] = sub_elem.text
 
@@ -79,18 +83,20 @@ def process_db_sub_elems(elem, elem_fields):
 		if sub_name.endswith("address"):
 			add_elems = sub_elem.getchildren()
 			for add_elem in add_elems:
-				elem_dict[sub_name + "_" + add_elem.tag] = add_elem.text
+                                if add_elem.text:
+				        elem_dict[sub_name + "_" + add_elem.tag] = format_element_text(add_elem)
 		elif sub_name not in elem_dict:
 			table_name = elem.tag + "_" + sub_name[:sub_name.find("_id")]
 			extra = {"table":table_name, "elements":dict.fromkeys(elem_fields[table_name])}
 			extra["elements"][elem.tag + "_id"] = elem.get("id")
-			extra["elements"][sub_name] = sub_elem.text
+			extra["elements"][sub_name] = format_element_text(sub_elem)
 			attributes = sub_elem.attrib
 			for a in attributes:
 				extra["elements"][a] = attributes[a]
 			extras.append(extra)
 		else:
-			elem_dict[sub_name] = sub_elem.text
+                        if sub_elem.text:
+			        elem_dict[sub_name] = format_element_text(sub_elem)
 	return elem_dict, extras
 
 def feed_to_element_files(output_directory, feed_file, element_props, version):


### PR DESCRIPTION
Some of the XML files we get contain newlines for some reason, which
makes for strange looking CSV files!

```
<directions>FROM HOFFNER AVE AND
GOLDENROD RD, GO NORTH ON
GOLDENROD, PAST CHARLIN PKWY
TO POLL ON LEFT.
</directions>
```