### PR TITLE
Misc fixes

### DIFF
--- a/feedtoflatfiles.py
+++ b/feedtoflatfiles.py
@@ -87,13 +87,16 @@ def process_db_sub_elems(elem, elem_fields):
 				        elem_dict[sub_name + "_" + add_elem.tag] = format_element_text(add_elem)
 		elif sub_name not in elem_dict:
 			table_name = elem.tag + "_" + sub_name[:sub_name.find("_id")]
-			extra = {"table":table_name, "elements":dict.fromkeys(elem_fields[table_name])}
-			extra["elements"][elem.tag + "_id"] = elem.get("id")
-			extra["elements"][sub_name] = format_element_text(sub_elem)
-			attributes = sub_elem.attrib
-			for a in attributes:
-				extra["elements"][a] = attributes[a]
-			extras.append(extra)
+			if table_name in elem_fields.keys():
+				extra = {"table":table_name, "elements":dict.fromkeys(elem_fields[table_name])}
+				extra["elements"][elem.tag + "_id"] = elem.get("id")
+				extra["elements"][sub_name] = format_element_text(sub_elem)
+				attributes = sub_elem.attrib
+				for a in attributes:
+					extra["elements"][a] = attributes[a]
+				extras.append(extra)
+			else:
+				print sub_name + " not a field type in " + table_name
 		else:
                         if sub_elem.text:
 			        elem_dict[sub_name] = format_element_text(sub_elem)

--- a/schemaprops.py
+++ b/schemaprops.py
@@ -3,7 +3,8 @@ from urllib import urlopen
 from os import path
 from collections import OrderedDict
 
-SCHEMA_URL = "https://github.com/votinginfoproject/vip-specification/raw/v3-archive/vip_spec_v"
+SCHEMA_URL = "https://raw.githubusercontent.com/votinginfoproject/vip-specification/v3-archive/vip_spec_v"
+#SCHEMA_URL = "https://github.com/votinginfoproject/vip-specification/raw/v3-archive/vip_spec_v"
 VALID_VERSIONS = ["4.0", "3.0", "2.3", "2.2", "2.1"]
 DEFAULT_VERSION = "3.0"
 
@@ -167,4 +168,3 @@ if __name__ == "__main__":
 	print sp.full_type_data("db")
 	print sp.full_type_data("element")
 	print sp.full_header_data("db")
-

--- a/schemaprops.py
+++ b/schemaprops.py
@@ -4,7 +4,6 @@ from os import path
 from collections import OrderedDict
 
 SCHEMA_URL = "https://raw.githubusercontent.com/votinginfoproject/vip-specification/v3-archive/vip_spec_v"
-#SCHEMA_URL = "https://github.com/votinginfoproject/vip-specification/raw/v3-archive/vip_spec_v"
 VALID_VERSIONS = ["4.0", "3.0", "2.3", "2.2", "2.1"]
 DEFAULT_VERSION = "3.0"
 


### PR DESCRIPTION
Some improvements:

updating schema url
if a bad tag gets added to a bunch of elements, rather than just dying, will carry on and print out info on what was skipped. The example here is that `<state_id>` got put into a ton of `<early_vote_site>'s`